### PR TITLE
Replace mkdir with mkdirp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "binary-install",
   "version": "0.0.0",
   "lockfileVersion": 1,
+  "preserveSymlinks": "1",
   "requires": true,
   "dependencies": {
     "axios": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "env-paths": "^2.2.0",
+    "mkdirp": "^0.5.1",
     "rimraf": "^3.0.0",
     "tar": "^5.0.5",
     "universal-url": "^2.0.0"

--- a/src/binary.js
+++ b/src/binary.js
@@ -1,9 +1,10 @@
-const { existsSync, mkdirSync } = require("fs");
+const { existsSync } = require("fs");
 const { homedir } = require("os");
 const { join } = require("path");
 const { spawnSync } = require("child_process");
 const { URL } = require("universal-url");
 const envPaths = require("env-paths");
+const mkdirp = require("mkdirp");
 
 const axios = require("axios");
 const tar = require("tar");
@@ -45,7 +46,7 @@ class Binary {
 
   _getInstallDirectory() {
     if (!existsSync(this.installDirectory)) {
-      mkdirSync(this.installDirectory);
+      mkdirp.sync(this.installDirectory);
     }
     return this.installDirectory;
   }
@@ -73,7 +74,7 @@ class Binary {
   install() {
     const dir = this._getInstallDirectory();
     if (!existsSync(dir)) {
-      mkdirSync(dir);
+      mkdirp.sync(dir);
     }
 
     this.binaryDirectory = join(dir, "bin");
@@ -82,7 +83,7 @@ class Binary {
       rimraf.sync(this.binaryDirectory);
     }
 
-    mkdirSync(this.binaryDirectory);
+    mkdirp.sync(this.binaryDirectory);
 
     console.log("Downloading release", this.url);
 

--- a/src/binary.js
+++ b/src/binary.js
@@ -57,7 +57,7 @@ class Binary {
     if (existsSync(binaryDirectory)) {
       this.binaryDirectory = binaryDirectory;
     } else {
-      throw `You have not installed ${name ? name : "this package"}`;
+      throw `You have not installed ${this.name ? this.name : "this package"}`;
     }
     return this.binaryDirectory;
   }


### PR DESCRIPTION
- Fixes #1 by replacing calls to `fs.mkdirSync` with `mkdirp.sync` from the [mkdirp](https://www.npmjs.com/package/mkdirp) package.
- Rectifies a bug where the variable `name` is used instead of `this.name` which resulted in a ReferenceError