### PR TITLE
feat: install binary to local/global node_modules bin by default

### DIFF
--- a/src/binary.js
+++ b/src/binary.js
@@ -39,7 +39,7 @@ class Binary {
     }
     this.url = url;
     this.name = data.name || -1;
-    this.installDirectory = data.installDirectory || envPaths(this.name).config;
+    this.installDirectory = data.installDirectory || join(__dirname, "bin");
     this.binaryDirectory = -1;
     this.binaryPath = -1;
   }


### PR DESCRIPTION
@EverlastingBugstopper I'm forwarding this change from `wasm-pack`. I didn't remove envPaths cuz I'm not quite sure how to test if this works correctly for both local and global installs. I figured you could release and RC and then use in a dummy binary to test.